### PR TITLE
Upgrade to Rust 1.88.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: ["main"]
 
 env:
-  RUST_VERSION: "1.81.0"
+  RUST_VERSION: "1.88.0"
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 env:
-  RUST_VERSION: "1.81.0"
+  RUST_VERSION: "1.88.0"
 
 jobs:
   release:

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,7 @@ fn parse_compression(compression: Option<Vec<String>>) -> (Algorithms, Quality) 
                     let q: u8 = match q.parse() {
                         Ok(q) => q,
                         Err(_) => {
-                            eprintln!("Error: invalid compression quality: {}", q);
+                            eprintln!("Error: invalid compression quality: {q}");
                             exit(1);
                         }
                     };
@@ -127,7 +127,7 @@ fn parse_compression(compression: Option<Vec<String>>) -> (Algorithms, Quality) 
                         }
                     }
                     _ => {
-                        eprintln!("Error: unknown compression algorithm: {}", s);
+                        eprintln!("Error: unknown compression algorithm: {s}");
                         exit(1);
                     }
                 }

--- a/src/precompress.rs
+++ b/src/precompress.rs
@@ -180,7 +180,7 @@ impl Compressor {
             let entry = match entry {
                 Ok(entry) => entry,
                 Err(err) => {
-                    eprintln!("Warning: {}", err);
+                    eprintln!("Warning: {err}");
                     continue;
                 }
             };


### PR DESCRIPTION
## Summary
- upgrade Rust toolchain for CI and releases

## Testing
- `cargo fmt --all -- --check` *(fails: rustfmt missing)*
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo build --locked`


------
https://chatgpt.com/codex/tasks/task_e_685e1d29c0dc8325bc33a0925f883c81